### PR TITLE
Fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "repository": "https://github.com/christopher-caldwell/react-kanban",
   "license": "MIT",
   "peerDependencies": {
+    "@hello-pangea/dnd": ">=16",
     "react": ">=16",
-    "react-dom": ">=16",
-    "@hello-pangea/dnd": ">=16"
+    "react-dom": ">=16"
   },
   "homepage": "https://christopher-caldwell.github.io/react-kanban",
   "devDependencies": {
@@ -46,12 +46,12 @@
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-cypress": "2.11.2",
     "eslint-plugin-flowtype": "^8.0.3",
-    "eslint-plugin-import": "2.20.2",
+    "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-jest": "23.13.2",
     "eslint-plugin-jest-dom": "2.1.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-react": "7.20.6",
+    "eslint-plugin-react": "^7.36.1",
     "eslint-plugin-react-hooks": "^4.0.8",
     "eslint-plugin-testing-library": "3.2.0",
     "gh-pages": "^4.0.0",


### PR DESCRIPTION
This fixes `npm install` command failing on main branch, which I also noticed on other PRs currently open. Hopefully this allows to get the other PRs being merged as well to get tests working and continue improvement of the repo.

```sh
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: @caldwell619/react-kanban@0.0.8
npm error Found: eslint@8.57.1
npm error node_modules/eslint
npm error   dev eslint@"^8.24.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer eslint@"2.x - 6.x" from eslint-plugin-import@2.20.2
npm error node_modules/eslint-plugin-import
npm error   dev eslint-plugin-import@"2.20.2" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```