### PR TITLE
fix: Type signature incorrect

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,7 @@
   "parser": "@typescript-eslint/parser",
   "extends": ["react-app", "plugin:@typescript-eslint/recommended"],
   "plugins": ["prettier"],
+  "ignorePatterns": ["dist/*"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "prettier/prettier": "error"

--- a/demo/src/features/uncontrolled/index.tsx
+++ b/demo/src/features/uncontrolled/index.tsx
@@ -16,6 +16,13 @@ export const UncontrolledBoardDemo: FC = () => {
         onCardRemove={({ board, card, column }) => {
           console.log({ board, card, column })
         }}
+        onCardDragEnd={(subjectCustomCard, source, destination) => {
+          console.log({
+            subjectCustomCard,
+            source,
+            destination
+          })
+        }}
       />
     </>
   )

--- a/src/features/board/components/Uncontrolled.tsx
+++ b/src/features/board/components/Uncontrolled.tsx
@@ -36,7 +36,7 @@ export const UncontrolledBoard = function <TCard extends Card>({
   // @ts-expect-error TS(7031) FIXME: Binding element 'source' implicitly has an 'any' t... Remove this comment to see the full error message
   const handleOnDragEnd = ({ source, destination, subject }, { moveCallback, notifyCallback }) => {
     const reorderedBoard = moveCallback(board, source, destination)
-    when(notifyCallback)((callback) => callback(reorderedBoard, subject, source, destination))
+    when(notifyCallback)((callback) => callback(subject, source, destination))
     setBoard(reorderedBoard)
   }
 


### PR DESCRIPTION
- Changed onCardDragEnd to send back correct payload

<!--- Provide a general summary of your changes in the Title above -->

## Description
Payload for the callback `onCardDragEnd` was incorrect. The type was correct, but the first argument was the board, instead of the TCard.

<!--- Describe your changes in detail -->

## Related Issue
#47 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Has the demo been updated?
Yes
<!-- If applicable -->

## Screenshots (if appropriate):
